### PR TITLE
make sha1 and md5 optional

### DIFF
--- a/cart_container/Cargo.toml
+++ b/cart_container/Cargo.toml
@@ -18,6 +18,11 @@ categories = ["algorithms", "compression", "encoding"]
 [lib]
 crate-type = ["lib"]
 
+[features]
+default = ["md5", "sha1"]
+md5 = ["dep:md-5"]
+sha1 = ["dep:sha1"]
+
 [dependencies]
 serde_json = "1.0" # JSON library
 
@@ -28,8 +33,8 @@ flate2 = "1"
 # crypto packages from the RustCrypto project
 # cipher = { version = "0.4", features = [ "std" ] }
 rc4 = "0.1"
-md-5 = "0.10"
-sha1 = "0.10"
+md-5 = { version= "0.10", optional = true }
+sha1 = { version = "0.10", optional = true }
 sha2 = "0.10"
 
 [dev-dependencies]

--- a/cart_container/src/cart.rs
+++ b/cart_container/src/cart.rs
@@ -296,7 +296,7 @@ pub fn unpack_stream<IN: Read, OUT: Write>(mut istream: IN, mut ostream: OUT,
 mod tests {
     use std::io::{SeekFrom, Seek};
 
-    use md5::Digest;
+    use sha2::Digest;
 
     use crate::cart::{JsonMap, BLOCK_SIZE, MANDATORY_HEADER_SIZE};
     use crate::digesters::default_digesters;

--- a/cart_container/src/digesters.rs
+++ b/cart_container/src/digesters.rs
@@ -3,7 +3,7 @@
 //! to include in a cart file footer.
 //! 
 
-use md5::Digest;
+use sha2::Digest;
 
 /// Interface for digests that produce footer entries
 pub trait Digester {
@@ -22,13 +22,16 @@ pub trait Digester {
 #[must_use]
 pub fn default_digesters() -> Vec<Box<dyn Digester>> {
     vec![
+        #[cfg(feature = "md5")]
         Box::new(MD5Digest::new()),
+        #[cfg(feature = "sha1")]
         Box::new(SHA1Digest::new()),
         Box::new(SHA256Digest::new()),
         Box::new(LengthDigest::new()),
     ]
 }
 
+#[cfg(feature = "md5")]
 /// Calculates the MD5 of the file body
 #[derive(Default)]
 #[must_use]
@@ -36,6 +39,7 @@ pub struct MD5Digest {
     hasher: md5::Md5
 }
 
+#[cfg(feature = "md5")]
 impl MD5Digest {
     /// Create digester to produce MD5
     pub fn new() -> Self {
@@ -43,6 +47,7 @@ impl MD5Digest {
     }
 }
 
+#[cfg(feature = "md5")]
 impl Digester for MD5Digest {
     fn update(&mut self, data: &[u8]) {
         self.hasher.update(data);
@@ -57,6 +62,7 @@ impl Digester for MD5Digest {
     }
 }
 
+#[cfg(feature = "sha1")]
 /// Calculates the SHA1 of the file body
 #[derive(Default)]
 #[must_use]
@@ -64,6 +70,7 @@ pub struct SHA1Digest {
     hasher: sha1::Sha1
 }
 
+#[cfg(feature = "sha1")]
 impl SHA1Digest {
     /// Create new digester to produce SHA1
     pub fn new() -> Self {
@@ -71,6 +78,7 @@ impl SHA1Digest {
     }
 }
 
+#[cfg(feature = "sha1")]
 impl Digester for SHA1Digest {
     fn update(&mut self, data: &[u8]) {
         self.hasher.update(data);


### PR DESCRIPTION
In some environments, the use of md5 and sha1 is prohibited.  This
enables the use of this crate in such enviornments.
